### PR TITLE
Added arm64 package to trufflehog dockerfile

### DIFF
--- a/Dockerfile.trufflehog
+++ b/Dockerfile.trufflehog
@@ -2,7 +2,17 @@ FROM python:3.11-alpine
 RUN apk add --no-cache bash git wget openssh-client ca-certificates \
     && rm -rf /var/cache/apk/* && \
     update-ca-certificates
-RUN wget https://github.com/trufflesecurity/trufflehog/releases/download/v3.28.5/trufflehog_3.28.5_linux_amd64.tar.gz -O /tmp/trufflehog.tar.gz && cd /tmp && tar zxf trufflehog.tar.gz && mv trufflehog /usr/bin && rm trufflehog.tar.gz LICENSE README.md
+RUN if [ $(uname -m) = "x86_64" ]; then \
+        wget https://github.com/trufflesecurity/trufflehog/releases/download/v3.28.5/trufflehog_3.28.5_linux_amd64.tar.gz -O /tmp/trufflehog.tar.gz \
+    ; elif [ $(uname -m) = "aarch64" ]; then \
+        wget https://github.com/trufflesecurity/trufflehog/releases/download/v3.28.5/trufflehog_3.28.5_linux_arm64.tar.gz -O /tmp/trufflehog.tar.gz \
+    ; else \
+        echo "Unsupported architecture" && exit 1 \
+    ; fi \
+    && cd /tmp \
+    && tar zxf trufflehog.tar.gz \
+    && mv trufflehog /usr/bin \
+    && rm trufflehog.tar.gz LICENSE README.md
 COPY ./requirements.txt /app/requirements.txt
 WORKDIR /app
 RUN chmod +x /usr/bin/trufflehog


### PR DESCRIPTION
Added arm64 package to the trufflehog docker file. It prevents exec format errors when running on different architectures as it pulls the correct release based on the user's architecture.

