### PR TITLE
fix empty localstorage bug

### DIFF
--- a/api.js
+++ b/api.js
@@ -535,7 +535,7 @@ async function set_up_api_server(app) {
                 "referer": payload.referer,
                 "user_agent": payload.user_agent,
                 "cookies": payload.cookies,
-                "localstorage": JSON.parse(payload.localstorage),
+                "localstorage": payload.localstorage ? JSON.parse(payload.localstorage) : {},
                 "title": payload.title,
                 "payload_url": payload.payload_url,
                 "origin": payload.origin,


### PR DESCRIPTION
Hi!

Today I discovered some strange case that leads to bug in admin panel.

Someone triggered my payload in local iframe or smth like this and `payload.localstorage` was empty. It leads to infinite freeze for ` /api/v1/payloadfires?page=1&limit=5`  method call because of such string:

`                "localstorage": JSON.parse(payload.localstorage), `. - it produced exception. 

So. I handled it. Please check it. And maybe for such cases when we got an exception in rest handler -> should we notify somehow on admin page ? because right now it just shows you 0 payload fires. 

Thanks and regards!